### PR TITLE
Change type of Column.setIndex() from int to Integer

### DIFF
--- a/src/main/java/com/smartsheet/api/models/Column.java
+++ b/src/main/java/com/smartsheet/api/models/Column.java
@@ -119,7 +119,7 @@ public class Column extends IdentifiableModel<Long> {
 	 *
 	 * @param index the new index
 	 */
-	public void setIndex(int index) {
+	public void setIndex(Integer index) {
 		this.index = index;
 	}
 


### PR DESCRIPTION
As an int, you can't null it out, and it's a disallowed field for POSTs,
so there is no way to POST a new column using an existing column that
you have fetched.  This change allows you to set index to null.
