### PR TITLE
Added Format serialization support

### DIFF
--- a/src/main/java/com/smartsheet/api/internal/json/FormatSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/FormatSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * #[license]
+ * Smartsheet Java SDK
+ * %%
+ * Copyright (C) 2014 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+package com.smartsheet.api.internal.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.smartsheet.api.models.format.Format;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+
+/**
+ * Serializes a Format object as a String appropriate for Smartsheet REST requests
+ * @author gbeirne
+ */
+public class FormatSerializer extends JsonSerializer<Format> {
+
+	@Override
+	public void serialize(final Format format, final JsonGenerator jsonGenerator, final SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+		jsonGenerator.writeString(format.getStringRepresentation());
+	}
+}

--- a/src/main/java/com/smartsheet/api/internal/json/JacksonJsonSerializer.java
+++ b/src/main/java/com/smartsheet/api/internal/json/JacksonJsonSerializer.java
@@ -70,10 +70,10 @@ public class JacksonJsonSerializer implements JsonSerializer {
 		// Excludes "id" field from being serialized to JSON for any IdentifiableModel class
 		OBJECT_MAPPER.addMixInAnnotations(IdentifiableModel.class, IdFieldExclusionMixin.class);
 		
-		//Add a custom deserializer that will convert a string to a Format object.
-		SimpleModule module = new SimpleModule("FormatDeserializerModule", Version.unknownVersion());
+		//Add custom deserializer and serializer that will convert a string to a Format object and vice versa.
+		SimpleModule module = new SimpleModule("FormatSerializationModule", Version.unknownVersion());
 		module.addDeserializer(Format.class, new FormatDeserializer());
-
+		module.addSerializer(Format.class, new FormatSerializer());
 		OBJECT_MAPPER.registerModule(module);
 	}
 

--- a/src/main/java/com/smartsheet/api/models/format/Format.java
+++ b/src/main/java/com/smartsheet/api/models/format/Format.java
@@ -75,6 +75,21 @@ public class Format {
 			return values[formatArray[attribute.ordinal()]];
 		}
 	}
+
+	/**
+	 * @return the String describing this format for {@link #Format(String)} or REST requests.
+	 */
+	public String getStringRepresentation(){
+		StringBuilder sb = new StringBuilder();
+		for(int i : formatArray){
+			if (i != UNSET) {
+				sb.append(String.valueOf(i));
+			}
+			sb.append(',');
+		}
+		sb.deleteCharAt(sb.lastIndexOf(","));
+		return sb.toString();
+	}
 	
 	/**
 	 * @return the {@link FontFamily}.


### PR DESCRIPTION
After unsuccessfully trying to set row format in an insert row request I made this small change. This commit adds a `getStringRepresentation()` method to the Format class complementing the String based constructor, adds a `FormatSerializer` class mirroring the FormatDeserializer class, and registers the `FormatSerializer` alongside the `FormatDeserializer` in the static init block of the `JacksonJsonSerializer` class. This commit appears to pass all unit tests and merge cleanly with any of the 2.0 branches but I'll admit that I haven't tested exhaustively. Hope this is helpful. If there is anything else you need from me I'd be happy to comply if I'm able.