### PR TITLE
fix failing logging test case

### DIFF
--- a/src/test/java/com/smartsheet/api/logging/LoggingTest.java
+++ b/src/test/java/com/smartsheet/api/logging/LoggingTest.java
@@ -79,7 +79,7 @@ public class LoggingTest {
     public void testCustomLogging() throws Exception {
         ByteArrayOutputStream traceStream = new ByteArrayOutputStream();
         DefaultHttpClient.setTraceStream(traceStream);
-        Smartsheet client = new SmartsheetBuilder().build();
+        Smartsheet client = new SmartsheetBuilder().setAccessToken("null").build();
         client.setTraces(Trace.Request, Trace.Response);    // should log entire request and response
         try {
             Sheet sheet = client.sheetResources().getSheet(42, null, null, null, null, null, 1, 1);


### PR DESCRIPTION
explicitly set the access token to null for this test case since it
could be coming from the environment.