### PR TITLE
Add initial mock scenario tests

### DIFF
--- a/smartsheet-sdk-java.iml
+++ b/smartsheet-sdk-java.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
@@ -9,8 +9,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/sample" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/license" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/mock-api-test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/main/java/com/smartsheet/api/Smartsheet.java
+++ b/src/main/java/com/smartsheet/api/Smartsheet.java
@@ -159,6 +159,14 @@ public interface Smartsheet {
     public void setAccessToken(String accessToken);
 
     /**
+     * <p>Set the SDK API test scenario.</p>
+     *
+     * @param apiScenario the new API scenario name
+     * @throws IllegalArgumentException if any argument is null/empty string
+     */
+    public void setAPIScenario(String apiScenario);
+
+    /**
      * <p>Enable request/response tracing in client</p>
      * @param levels - what to trace (if anything; null if not tracing at all)
      */

--- a/src/main/java/com/smartsheet/api/SmartsheetBuilder.java
+++ b/src/main/java/com/smartsheet/api/SmartsheetBuilder.java
@@ -66,6 +66,13 @@ public class SmartsheetBuilder {
     private String accessToken;
 
     /**
+     * <p>Represents the API scenario.</p>
+     *
+     * <p>It can be set using corresponding setter.</p>
+     */
+    private String apiScenario;
+
+    /**
      * <p>Represents the assumed user.</p>
      *
      * <p>It can be set using corresponding setter.</p>
@@ -140,6 +147,17 @@ public class SmartsheetBuilder {
      */
     public SmartsheetBuilder setAccessToken(String accessToken) {
         this.accessToken = accessToken;
+        return this;
+    }
+
+    /**
+     * <p>Set the API scenario.</p>
+     *
+     * @param apiScenario the API scenario
+     * @return the smartsheet builder
+     */
+    public SmartsheetBuilder setAPIScenario(String apiScenario) {
+        this.apiScenario = apiScenario;
         return this;
     }
 
@@ -231,6 +249,16 @@ public class SmartsheetBuilder {
     }
 
     /**
+     * <p>Gets the API scenario.</p>
+     *
+     * @return the API scenario
+     */
+    public String getAPIScenario() {
+        return apiScenario;
+    }
+
+
+    /**
      * <p>Gets the assumed user.</p>
      *
      * @return the assumed user
@@ -266,7 +294,7 @@ public class SmartsheetBuilder {
             accessToken = System.getenv("SMARTSHEET_ACCESS_TOKEN");
         }
 
-        SmartsheetImpl smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, jsonSerializer, changeAgent);
+        SmartsheetImpl smartsheet = new SmartsheetImpl(baseURI, accessToken, httpClient, jsonSerializer, changeAgent, apiScenario);
 
         if(calcBackoff != null) {
             smartsheet.setCalcBackoff(calcBackoff);

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -347,7 +347,7 @@ public abstract class AbstractResources {
         HttpPost uploadFile = createHttpPost(this.getSmartsheet().getBaseURI().resolve(path));
 
         try {
-            uploadFile.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+            uploadFile.setHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -840,7 +840,7 @@ public abstract class AbstractResources {
         HttpPost uploadFile = createHttpPost(this.getSmartsheet().getBaseURI().resolve(url));
 
         try {
-            uploadFile.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
+            uploadFile.setHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -988,6 +988,7 @@ public abstract class AbstractResources {
      Map<String,String> createHeaders() {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", "Bearer " + smartsheet.getAccessToken());
+        headers.put("Content-Type", "application/json");
 
         // Set assumed user
         if (smartsheet.getAssumedUser() != null) {

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -997,13 +997,16 @@ public abstract class AbstractResources {
                 throw new RuntimeException ("Unsupported encode. You must support utf-8 for the Smartsheet Java SDK to work",e);
             }
         }
-        if (smartsheet.getChangeAgent() != null) {
-            try {
-                headers.put("Smartsheet-Change-Agent", URLEncoder.encode(smartsheet.getChangeAgent(), "utf-8"));
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException ("Unsupported encode. You must support utf-8 for the Smartsheet Java SDK to work",e);
-            }
-        }
+         if (smartsheet.getChangeAgent() != null) {
+             try {
+                 headers.put("Smartsheet-Change-Agent", URLEncoder.encode(smartsheet.getChangeAgent(), "utf-8"));
+             } catch (UnsupportedEncodingException e) {
+                 throw new RuntimeException ("Unsupported encode. You must support utf-8 for the Smartsheet Java SDK to work",e);
+             }
+         }
+         if (smartsheet.getAPIScenario() != null && !smartsheet.getAPIScenario().isEmpty()) {
+            headers.put("Api-Scenario", smartsheet.getAPIScenario());
+         }
         return headers;
     }
 

--- a/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
@@ -178,6 +178,15 @@ public class SmartsheetImpl implements Smartsheet {
     private final AtomicReference<String> accessToken;
 
     /**
+     * Represents the AtomicReference for API scenario.
+     *
+     * It will be initialized in constructor and will not change afterwards. The underlying value will be initially set
+     * as null, and can be set via corresponding setter, therefore effectively the access token can be updated in the
+     * SmartsheetImpl in thread safe manner.
+     */
+    private final AtomicReference<String> apiScenario;
+
+    /**
      * Represents the AtomicReference for change agent
      *
      * It will be initialized in constructor and will not change afterwards.
@@ -250,8 +259,9 @@ public class SmartsheetImpl implements Smartsheet {
      * @param jsonSerializer the json serializer (optional)
      */
     public SmartsheetImpl(String baseURI, String accessToken, HttpClient httpClient, JsonSerializer jsonSerializer) {
-        this(baseURI, accessToken, httpClient, jsonSerializer, null);
+        this(baseURI, accessToken, httpClient, jsonSerializer, null, null);
     }
+
     /**
      * Create an instance with given server URI, HttpClient (optional) and JsonSerializer (optional)
      *
@@ -262,7 +272,7 @@ public class SmartsheetImpl implements Smartsheet {
      * @param httpClient the http client (optional)
      * @param jsonSerializer the json serializer (optional)
      */
-    public SmartsheetImpl(String baseURI, String accessToken, HttpClient httpClient, JsonSerializer jsonSerializer, String changeAgent) {
+    public SmartsheetImpl(String baseURI, String accessToken, HttpClient httpClient, JsonSerializer jsonSerializer, String changeAgent, String apiScenario) {
         Util.throwIfNull(baseURI);
         Util.throwIfEmpty(baseURI);
 
@@ -287,6 +297,7 @@ public class SmartsheetImpl implements Smartsheet {
         this.search = new AtomicReference<SearchResources>();
         this.assumedUser = new AtomicReference<String>();
         this.accessToken = new AtomicReference<String>(accessToken);
+        this.apiScenario = new AtomicReference<String>(apiScenario);
         this.changeAgent = new AtomicReference<String>(changeAgent);
         this.reports = new AtomicReference<ReportResources>();
         this.serverInfo = new AtomicReference<ServerInfoResources>();
@@ -350,6 +361,15 @@ public class SmartsheetImpl implements Smartsheet {
      */
     String getAccessToken() {
         return accessToken.get();
+    }
+
+    /**
+     * Return the API scenario
+     *
+     * @return the API scenario
+     */
+    String getAPIScenario() {
+        return apiScenario.get();
     }
 
     /**
@@ -571,8 +591,20 @@ public class SmartsheetImpl implements Smartsheet {
      *
      * @param accessToken the new access token
      */
-    public void setAccessToken(String accessToken) {
-        this.accessToken.set(accessToken);
+    public void setAccessToken(String accessToken) { this.accessToken.set(accessToken); }
+
+    /**
+     * Set the API Scenario to use.
+     *
+     * Parameters: - apiScenario : the API Scenario
+     *
+     * Returns: None
+     *
+     *
+     * @param apiScenario the new API Scenario
+     */
+    public void setAPIScenario(String apiScenario) {
+        this.apiScenario.set(apiScenario);
     }
 
     public void setCalcBackoff(CalcBackoff calcBackoff) {

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/HelperFunctions.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/HelperFunctions.java
@@ -2,7 +2,6 @@ package com.smartsheet.api.sdk_test;
 
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetBuilder;
-import com.smartsheet.api.oauth.Token;
 
 public class HelperFunctions {
 	public static Smartsheet SetupClient(String apiScenario){

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/HelperFunctions.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/HelperFunctions.java
@@ -1,0 +1,17 @@
+package com.smartsheet.api.sdk_test;
+
+import com.smartsheet.api.Smartsheet;
+import com.smartsheet.api.SmartsheetBuilder;
+import com.smartsheet.api.oauth.Token;
+
+public class HelperFunctions {
+	public static Smartsheet SetupClient(String apiScenario){
+		Smartsheet ss = new SmartsheetBuilder()
+			.setBaseURI("http://localhost:8082/")
+			.setAccessToken("aaaaaaaaaaaaaaaaaaaaaaaaaa")
+			.setAPIScenario(apiScenario)
+			.build();
+
+		return ss;
+	}
+}

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
@@ -1,0 +1,763 @@
+package com.smartsheet.api.sdk_test;
+/*
+ * #[license]
+ * Smartsheet SDK for Java
+ * %%
+ * Copyright (C) 2014 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+
+
+import com.smartsheet.api.Smartsheet;
+import com.smartsheet.api.SmartsheetException;
+import com.smartsheet.api.models.*;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.List;
+
+import java.util.Arrays;
+
+public class RowTests {
+
+	
+	@Test
+	public void ListSheets_NoParams()
+	{
+		try {
+			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
+			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
+			Assert.assertEquals(sheets.getData().get(0).getName(), "Copy of Sample Sheet");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_AssignValues_String()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - String");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Apple");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("Red Fruit");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue("Banana");
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("Yellow Fruit");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1L, Arrays.asList(rowA,rowB));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_Location_Top()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Top");
+
+			Row rowA = new Row();
+			rowA.setToTop(true);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Apple");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("Red Fruit");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "Apple");
+			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 1);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+
+	}
+
+  	@Test
+	public void addRows_Location_Bottom()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Bottom");
+
+			Row rowA = new Row();
+			rowA.setToBottom(true);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Apple");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("Red Fruit");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "Apple");
+			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 100);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+//	@Test
+//	public void addRows_Location_Indent()
+//	{
+//		try{
+//			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Indent");
+//
+//			Row rowA = new Row();
+//			rowA.setIndent(3);
+//			rowA.setToBottom(true);
+//			Cell cell1 = new Cell();
+//			cell1.setColumnId(101L);
+//			cell1.setValue("Apple");
+//			Cell cell2 = new Cell();
+//			cell2.setColumnId(102L);
+//			cell2.setValue("Red Fruit");
+//			rowA.setCells(Arrays.asList(cell1, cell2));
+//
+//			// Update rows in sheet
+//			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+//
+//			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "Apple");
+//			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 100);
+//			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+//		}catch(Exception ex){
+//			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+//		}
+//	}
+
+	@Test
+	public void addRows_AssignValues_Int()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Int");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue(100);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("One Hundred");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue(2.1);
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("Two Point One");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), 100);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_AssignValues_Bool()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Bool");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue(true);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("This is True");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue(false);
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("This is False");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
+
+			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 10);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), true);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+//	//@Test
+//	//public void addRows_AssignValues_Date()
+//	//{
+//	//    Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Date");
+//
+//	//    Row rowA = new Row
+//	//    {
+//	//        Cells = new List<Cell>
+//	//        {
+//	//            new Cell{
+//	//                ColumnId = 101,
+//	//                ObjectValue = new ObjectType()
+//	//                }
+//	//            },
+//	//            new Cell{
+//	//                ColumnId = 102,
+//	//                Value = "This is True"
+//	//            }
+//	//        }
+//	//    };
+//
+//	//    Row rowB = new Row
+//	//    {
+//	//        Cells = new List<Cell>
+//	//        {
+//	//            new Cell{
+//	//                ColumnId = 101,
+//	//                Value = false
+//	//            },
+//	//            new Cell{
+//	//                ColumnId = 102,
+//	//                Value = "This is False"
+//	//            }
+//	//        }
+//	//    };
+//
+//	//    // Update rows in sheet
+//	//    List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, new Row[] { rowA, rowB });
+//
+//	//    Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
+//	//    Cell cell = row.Cells.Where(c => c.Value.Equals(true)).FirstOrDefault();
+//
+//	//    Assert.AreEqual(cell.ColumnId, 101);
+//	//}
+//
+@Test
+	public void addRows_AssignFormulae()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Formulae");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setFormula("=SUM([Column2]3, [Column2]4)*2");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setFormula("=SUM([Column2]3, [Column2]3, [Column2]4)");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getFormula(), "=SUM([Column2]3, [Column2]3, [Column2]4)");
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_AssignValues_Hyperlink()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Google");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setUrl("http://google.com");
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Bing");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setUrl("http://bing.com");
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "Google");
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getHyperlink().getUrl(), "http://google.com");
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_AssignValues_HyperlinkSheetID()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink SheetID");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Sheet2");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setSheetId(2L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Sheet3");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setSheetId(3L);
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getValue(), "Sheet3");
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue(), 3L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_AssignValues_HyperlinkReportID()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Hyperlink ReportID");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Report9");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setReportId(9L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Report8");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setReportId(8L);
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getValue(), "Report8");
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue(), 8L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_Invalid_AssignHyperlinkUrlandSheetId()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Hyperlink URL and SheetId");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Google");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setUrl("http://google.com");
+			hyperlink1.setSheetId(2L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Bing");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setUrl("http://bing.com");
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void addRows_Invalid_AssignValueAndFormulae()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Invalid - Assign Value and Formulae");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setFormula("=SUM([Column2]3, [Column2]4)*2");
+			cell1.setValue("20");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setFormula("=SUM([Column2]3, [Column2]3, [Column2]4)");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_String()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - String");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Apple");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("Red Fruit");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			rowB.setId(11L);
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue("Banana");
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("Yellow Fruit");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), "Apple");
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_Int()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Int");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue(100);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("One Hundred");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			rowB.setId(11L);
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue(2.1);
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("Two Point One");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), 100);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_Bool()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Bool");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue(true);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setValue("This is True");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			Row rowB = new Row();
+			rowB.setId(11L);
+			Cell cell3 = new Cell();
+			cell3.setColumnId(101L);
+			cell3.setValue(false);
+			Cell cell4 = new Cell();
+			cell4.setColumnId(102L);
+			cell4.setValue("This is False");
+			rowB.setCells(Arrays.asList(cell3, cell4));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1L, Arrays.asList(rowA,rowB));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), true);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignFormulae()
+	{
+		try{
+			Smartsheet ss =  HelperFunctions.SetupClient("Update Rows - Assign Formulae");
+
+			Row rowA = new Row();
+			rowA.setId(11L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setFormula("=SUM([Column2]3, [Column2]4)*2");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setFormula("=SUM([Column2]3, [Column2]3, [Column2]4)");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getFormula(), "=SUM([Column2]3, [Column2]3, [Column2]4)");
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_Hyperlink()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Google");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setUrl("http://google.com");
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Bing");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setUrl("http://bing.com");
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), "Google");
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getHyperlink().getUrl(), "http://google.com");
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_HyperlinkSheetID()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink SheetID");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Sheet2");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setSheetId(2L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Sheet3");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setSheetId(3L);
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getValue(), "Sheet3");
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getHyperlink().getSheetId().longValue(), 3L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_AssignValues_HyperlinkReportID()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Assign Values - Hyperlink ReportID");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Report9");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setReportId(9L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Report8");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setReportId(8L);
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getValue(), "Report8");
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.assertEquals(addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue(), 8L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_Invalid_AssignHyperlinkUrlandSheetId()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink URL and SheetId");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("Google");
+			Hyperlink hyperlink1 = new Hyperlink();
+			hyperlink1.setUrl("http://google.com");
+			hyperlink1.setSheetId(2L);
+			cell1.setHyperlink(hyperlink1);
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell1.setValue("Bing");
+			Hyperlink hyperlink2 = new Hyperlink();
+			hyperlink2.setUrl("http://bing.com");
+			cell2.setHyperlink(hyperlink1);
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_Invalid_AssignValueAndFormulae()
+	{
+		try{
+			Smartsheet ss =  HelperFunctions.SetupClient("Update Rows - Invalid - Assign Value and Formulae");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setFormula("=SUM([Column2]3, [Column2]4)*2");
+			cell1.setValue("20");
+			Cell cell2 = new Cell();
+			cell2.setColumnId(102L);
+			cell2.setFormula("=SUM([Column2]3, [Column2]3, [Column2]4)");
+			rowA.setCells(Arrays.asList(cell1, cell2));
+
+			// Update rows in sheet
+			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+}

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
@@ -23,6 +23,7 @@ package com.smartsheet.api.sdk_test;
 import com.smartsheet.api.Smartsheet;
 import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
+import com.smartsheet.api.models.enums.ObjectValueType;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.List;
@@ -225,7 +226,6 @@ public class RowTests {
 
 			Assert.assertEquals(addedRows.get(0).getCells().get(1).getFormula(), "=SUM([Column2]3, [Column2]3, [Column2]4)");
 			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
-			Assert.fail("hello");
 
 		}catch(Exception ex){
 			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
@@ -388,6 +388,39 @@ public class RowTests {
 			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
 		}
 	}
+
+	@Test
+	public void AddRows_AssignObjectValue_PredecessorList()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Object Value - Predecessor List");
+
+			Row rowA = new Row();
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			Duration duration = new Duration();
+			duration.setDays(2.0);
+			duration.setHours(4.0);
+			Predecessor predecessor = new Predecessor();
+			predecessor.setRowId(10L);
+			predecessor.setType("FS");
+			predecessor.setLag(duration);
+			PredecessorList predecessorList = new PredecessorList();
+			predecessorList.setPredecessors(Arrays.asList(predecessor));
+			cell1.setObjectValue(predecessorList);
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+
+
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "2FS +2d 4h");
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
 
 	@Test
 	public void UpdateRows_AssignValues_String()
@@ -684,6 +717,172 @@ public class RowTests {
 
 		}catch(SmartsheetException ex){
 			Assert.assertEquals(ex.getMessage(), "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void UpdateRows_ClearValue_TextNumber()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Text Number");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("");
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), null);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_ClearValue_Checkbox()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Checkbox");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("");
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), false);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_ClearValue_Hyperlink()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Hyperlink");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("");
+			cell1.setHyperlink(null);
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), null);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getHyperlink(), null);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_ClearValue_CellLink()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Clear Value - Cell Link");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("");
+			cell1.setLinkInFromCell(null);
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), null);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getLinkInFromCell(), null);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_Invalid_AssignHyperlinkAndCellLink()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Invalid - Assign Hyperlink and Cell Link");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			Cell cell1 = new Cell();
+			cell1.setColumnId(101L);
+			cell1.setValue("");
+			Hyperlink hyperlink = new Hyperlink();
+			hyperlink.setUrl("www.google.com");
+			cell1.setHyperlink(hyperlink);
+			CellLink cellLink = new CellLink();
+			cellLink.setRowId(20L);
+			cellLink.setSheetId(2L);
+			cellLink.setColumnId(201L);
+			cell1.setLinkInFromCell(cellLink);
+			rowA.setCells(Arrays.asList(cell1));
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "Only one of cell.hyperlink or cell.linkInFromCell may be non-null.");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_Location_Top()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Location - Top");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			rowA.setToTop(true);
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getId().longValue(), 10L);
+			Assert.assertEquals(updatedRows.get(0).getRowNumber().longValue(), 1L);
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+    @Test
+	public void UpdateRows_Location_Bottom()
+	{
+		try{
+			Smartsheet ss = HelperFunctions.SetupClient("Update Rows - Location - Bottom");
+
+			Row rowA = new Row();
+			rowA.setId(10L);
+			rowA.setToBottom(true);
+
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
+
+			Assert.assertEquals(updatedRows.get(0).getId().longValue(), 10L);
+			Assert.assertEquals(updatedRows.get(0).getRowNumber().longValue(), 100L);
+
 		}catch(Exception ex){
 			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
 		}

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/RowTests.java
@@ -133,34 +133,6 @@ public class RowTests {
 		}
 	}
 
-//	@Test
-//	public void addRows_Location_Indent()
-//	{
-//		try{
-//			Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Location - Indent");
-//
-//			Row rowA = new Row();
-//			rowA.setIndent(3);
-//			rowA.setToBottom(true);
-//			Cell cell1 = new Cell();
-//			cell1.setColumnId(101L);
-//			cell1.setValue("Apple");
-//			Cell cell2 = new Cell();
-//			cell2.setColumnId(102L);
-//			cell2.setValue("Red Fruit");
-//			rowA.setCells(Arrays.asList(cell1, cell2));
-//
-//			// Update rows in sheet
-//			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
-//
-//			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), "Apple");
-//			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 100);
-//			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
-//		}catch(Exception ex){
-//			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
-//		}
-//	}
-
 	@Test
 	public void addRows_AssignValues_Int()
 	{
@@ -224,7 +196,7 @@ public class RowTests {
 			// Update rows in sheet
 			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA, rowB));
 
-			Assert.assertEquals(addedRows.get(0).getRowNumber().intValue(), 10);
+			Assert.assertEquals(addedRows.get(0).getId().intValue(), 10);
 			Assert.assertEquals(addedRows.get(0).getCells().get(0).getValue(), true);
 			Assert.assertEquals(addedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
 
@@ -233,51 +205,6 @@ public class RowTests {
 		}
 	}
 
-//	//@Test
-//	//public void addRows_AssignValues_Date()
-//	//{
-//	//    Smartsheet ss = HelperFunctions.SetupClient("Add Rows - Assign Values - Date");
-//
-//	//    Row rowA = new Row
-//	//    {
-//	//        Cells = new List<Cell>
-//	//        {
-//	//            new Cell{
-//	//                ColumnId = 101,
-//	//                ObjectValue = new ObjectType()
-//	//                }
-//	//            },
-//	//            new Cell{
-//	//                ColumnId = 102,
-//	//                Value = "This is True"
-//	//            }
-//	//        }
-//	//    };
-//
-//	//    Row rowB = new Row
-//	//    {
-//	//        Cells = new List<Cell>
-//	//        {
-//	//            new Cell{
-//	//                ColumnId = 101,
-//	//                Value = false
-//	//            },
-//	//            new Cell{
-//	//                ColumnId = 102,
-//	//                Value = "This is False"
-//	//            }
-//	//        }
-//	//    };
-//
-//	//    // Update rows in sheet
-//	//    List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, new Row[] { rowA, rowB });
-//
-//	//    Row row = addedRows.Where(r => r.Id == 10).FirstOrDefault();
-//	//    Cell cell = row.Cells.Where(c => c.Value.Equals(true)).FirstOrDefault();
-//
-//	//    Assert.AreEqual(cell.ColumnId, 101);
-//	//}
-//
 @Test
 	public void addRows_AssignFormulae()
 	{
@@ -298,6 +225,7 @@ public class RowTests {
 
 			Assert.assertEquals(addedRows.get(0).getCells().get(1).getFormula(), "=SUM([Column2]3, [Column2]3, [Column2]4)");
 			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.fail("hello");
 
 		}catch(Exception ex){
 			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
@@ -319,10 +247,10 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Bing");
+			cell2.setValue("Bing");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setUrl("http://bing.com");
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
@@ -352,10 +280,10 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Sheet3");
+			cell2.setValue("Sheet3");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setSheetId(3L);
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
@@ -385,10 +313,10 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Report8");
+			cell2.setValue("Report8");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setReportId(8L);
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
@@ -419,10 +347,10 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Bing");
+			cell2.setValue("Bing");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setUrl("http://bing.com");
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
@@ -589,7 +517,7 @@ public class RowTests {
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getFormula(), "=SUM([Column2]3, [Column2]3, [Column2]4)");
 			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
@@ -615,14 +543,14 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Bing");
+			cell2.setValue("Bing");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setUrl("http://bing.com");
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getValue(), "Google");
 			Assert.assertEquals(updatedRows.get(0).getCells().get(0).getColumnId().longValue(), 101L);
@@ -649,14 +577,14 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Sheet3");
+			cell2.setValue("Sheet3");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setSheetId(3L);
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getValue(), "Sheet3");
 			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
@@ -683,18 +611,18 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Report8");
+			cell2.setValue("Report8");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setReportId(8L);
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> addedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
-			Assert.assertEquals(addedRows.get(0).getCells().get(1).getValue(), "Report8");
-			Assert.assertEquals(addedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
-			Assert.assertEquals(addedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue(), 8L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getValue(), "Report8");
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getColumnId().longValue(), 102L);
+			Assert.assertEquals(updatedRows.get(0).getCells().get(1).getHyperlink().getReportId().longValue(), 8L);
 
 		}catch(Exception ex){
 			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
@@ -718,14 +646,14 @@ public class RowTests {
 			cell1.setHyperlink(hyperlink1);
 			Cell cell2 = new Cell();
 			cell2.setColumnId(102L);
-			cell1.setValue("Bing");
+			cell2.setValue("Bing");
 			Hyperlink hyperlink2 = new Hyperlink();
 			hyperlink2.setUrl("http://bing.com");
-			cell2.setHyperlink(hyperlink1);
+			cell2.setHyperlink(hyperlink2);
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
 			Assert.assertEquals(ex.getMessage(), "hyperlink.url must be null for sheet, report, or Sight hyperlinks.");
@@ -752,7 +680,7 @@ public class RowTests {
 			rowA.setCells(Arrays.asList(cell1, cell2));
 
 			// Update rows in sheet
-			List<Row> updatedRows = ss.sheetResources().rowResources().addRows(1, Arrays.asList(rowA));
+			List<Row> updatedRows = ss.sheetResources().rowResources().updateRows(1, Arrays.asList(rowA));
 
 		}catch(SmartsheetException ex){
 			Assert.assertEquals(ex.getMessage(), "If cell.formula is specified, then value, objectValue, image, hyperlink, and linkInFromCell must not be specified.");

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/SheetTests.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/SheetTests.java
@@ -21,12 +21,16 @@ package com.smartsheet.api.sdk_test;
 
 
 import com.smartsheet.api.Smartsheet;
+import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.models.*;
 
+import com.smartsheet.api.models.enums.SourceInclusion;
 import org.junit.Assert;
 import org.junit.Test;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+
 
 public class SheetTests {
 
@@ -43,4 +47,34 @@ public class SheetTests {
 		}
 	}
 
+	@Test
+	public void ListSheets_IncludeOwnerInfo()
+	{
+		try{
+			Smartsheet ss =  HelperFunctions.SetupClient("List Sheets - Include Owner Info");
+			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(EnumSet.of(SourceInclusion.OWNERINFO), null, null);
+			Assert.assertEquals(sheets.getData().get(0).getOwner(),"john.doe@smartsheet.com");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+	@Test
+	public void CreateSheet__Invalid_NoColumns()
+	{
+		try {
+			Smartsheet ss = HelperFunctions.SetupClient("Create Sheet - Invalid - No Columns");
+
+			Sheet sheetA = new Sheet();
+			sheetA.setName("New Sheet");
+			sheetA.setColumns(new ArrayList<Column>());
+			ss.sheetResources().createSheet(sheetA);
+
+		}catch(SmartsheetException ex){
+			Assert.assertEquals(ex.getMessage(), "The new sheet requires either a fromId or columns.");
+
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
 }

--- a/src/mock-api-test/java/com.smartsheet.api/sdk_test/SheetTests.java
+++ b/src/mock-api-test/java/com.smartsheet.api/sdk_test/SheetTests.java
@@ -1,0 +1,46 @@
+package com.smartsheet.api.sdk_test;
+/*
+ * #[license]
+ * Smartsheet SDK for Java
+ * %%
+ * Copyright (C) 2014 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+
+
+import com.smartsheet.api.Smartsheet;
+import com.smartsheet.api.models.*;
+
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SheetTests {
+
+	
+	@Test
+	public void ListSheets_NoParams()
+	{
+		try {
+			Smartsheet ss = HelperFunctions.SetupClient("List Sheets - No Params");
+			PagedResult<Sheet> sheets = ss.sheetResources().listSheets(null, null, null);
+			Assert.assertEquals(sheets.getData().get(0).getName(), "Copy of Sample Sheet");
+		}catch(Exception ex){
+			Assert.fail(String.format("Exception: %s Detail: %s", ex.getMessage(), ex.getCause()));
+		}
+	}
+
+}

--- a/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
+++ b/src/test/java/com/smartsheet/api/internal/AbstractResourcesTest.java
@@ -39,7 +39,7 @@ public class AbstractResourcesTest {
     @Test
     public void testHeaders() {
 
-        AbstractResources resources = new AbstractResources(new SmartsheetImpl("doesnt/matter", tokenValue,  new DefaultHttpClient(), null, changeAgent)) {};
+        AbstractResources resources = new AbstractResources(new SmartsheetImpl("doesnt/matter", tokenValue,  new DefaultHttpClient(), null, changeAgent, null)) {};
 
         Map<String, String> headers = resources.createHeaders();
         assertEquals(headers.get("Authorization"), "Bearer " + tokenValue);
@@ -48,7 +48,7 @@ public class AbstractResourcesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void createResourceWithObjectClassNull() throws SmartsheetException {
-        AbstractResources resources = new AbstractResources(new SmartsheetImpl(SmartsheetBuilder.DEFAULT_BASE_URI, tokenValue,  new DefaultHttpClient(), null, changeAgent)) {};
+        AbstractResources resources = new AbstractResources(new SmartsheetImpl(SmartsheetBuilder.DEFAULT_BASE_URI, tokenValue,  new DefaultHttpClient(), null, changeAgent, null)) {};
         Home home = new Home();
 
         resources.createResource("someValidPath", null, home);

--- a/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SmartsheetImplTest.java
@@ -119,14 +119,16 @@ public class SmartsheetImplTest extends ResourcesImplBase {
     public void testReports() {
         assertNotNull(smartsheet.reportResources());
     }
-    @Test
-    public void testSetAssumedUser() {
-        smartsheet.setAssumedUser("user");
-    }
 
     @Test
-    public void testSetAccessToken() {
-        smartsheet.setAccessToken("1234");
+    public void testSetAssumedUser() { smartsheet.setAssumedUser("user"); }
+
+    @Test
+    public void testSetAccessToken() { smartsheet.setAccessToken("1234"); }
+
+    @Test
+    public void testSetAPIScenario() {
+        smartsheet.setAPIScenario("Scenario Name");
     }
 
     @Test


### PR DESCRIPTION
This PR adds the new Mock API tests. These test the SDK using a mock api that verifies requests are properly formatted through set test scenarios.

This PR also fixes a small bugs with the SDK that were breaking the mock api tests. Specifically, adding a default Content-Type header and including the Api-Scenario header on Mock API test calls were fixed.

If you'd like to run the tests locally, download the latest mock api bundle here: https://github.com/stollgr/wiremock-scenario-templating/releases. Unzip the bundle and, in a bash shell, run launch.sh. View the README in the bundle for more info.

Once the mock server is running, you can execute the mock api tests the same way you would run unit test in you JAVA IDE. The Mock API tests reside in \src\mock-api-test\java\com.smartsheet.api\sdk_test