### PR TITLE
Create a public interface for uploading attachments as input streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/integration-test/resources/config.properties
 .settings/
 .vscode/
 bin/
+/**/.DS_Store

--- a/smartsheet-sdk-java.iml
+++ b/smartsheet-sdk-java.iml
@@ -10,6 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/mock-api-test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/license" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
@@ -22,6 +22,7 @@ import com.smartsheet.api.models.Attachment;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 /**
  * <p>This interface provides methods to access CommentAttachment resources.</p>
@@ -72,6 +73,20 @@ public interface CommentAttachmentResources {
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Attachment attachFile(long sheetId, long commentId, File file, String contentType) throws FileNotFoundException, SmartsheetException;
+
+    /**
+     * <p>Attach file for simple upload.</p>
+     *
+     * @param sheetId the sheet id
+     * @param commentId the comment id
+     * @param inputStream the attachment data inputStream
+     * @param contentType the content type
+     * @param contentLength the content length
+     * @param attachmentName the name of the attachment
+     * @return the attachment
+     * @throws SmartsheetException the smartsheet exception
+     */
+    public Attachment attachFileWithSimpleUpload(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 
 //    /**
 //     * <p>Attach a file to a comment with multipart upload.</p>

--- a/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/CommentAttachmentResources.java
@@ -86,7 +86,7 @@ public interface CommentAttachmentResources {
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    public Attachment attachFile(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 
 //    /**
 //     * <p>Attach a file to a comment with multipart upload.</p>

--- a/src/main/java/com/smartsheet/api/RowAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/RowAttachmentResources.java
@@ -26,6 +26,7 @@ import com.smartsheet.api.models.PaginationParameters;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 /**
  * <p>This interface provides methods to access RowAttachment resources.</p>
@@ -101,4 +102,18 @@ public interface RowAttachmentResources{
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Attachment attachFile(long sheetId, long rowId, File file, String contentType) throws FileNotFoundException, SmartsheetException;
+
+    /**
+     * <p>Attach file for simple upload.</p>
+     *
+     * @param sheetId the sheet id
+     * @param rowId the row id
+     * @param inputStream the attachment data inputStream
+     * @param contentType the content type
+     * @param contentLength the content length
+     * @param attachmentName the name of the attachment
+     * @return the attachment
+     * @throws SmartsheetException the smartsheet exception
+     */
+    public Attachment attachFileWithSimpleUpload(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/RowAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/RowAttachmentResources.java
@@ -115,5 +115,5 @@ public interface RowAttachmentResources{
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    public Attachment attachFile(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 }

--- a/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
@@ -24,6 +24,7 @@ import com.smartsheet.api.models.PaginationParameters;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 public interface SheetAttachmentResources {
 
@@ -130,6 +131,19 @@ public interface SheetAttachmentResources {
      * @throws SmartsheetException if there is any other error during the operation
      */
     public Attachment attachFile(long sheetId, File file, String contentType) throws FileNotFoundException, SmartsheetException;
+
+    /**
+     * <p>Attach file for simple upload.</p>
+     *
+     * @param sheetId the sheet id
+     * @param inputStream attachment data inputStream
+     * @param contentType the content type
+     * @param contentLength the content length
+     * @param attachmentName the name of the attachment
+     * @return the attachment
+     * @throws SmartsheetException the smartsheet exception
+     */
+    public Attachment attachFileWithSimpleUpload(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 
     /**
      * <p>Creates an object of AttachmentVersioningResources for access to versioning through SheetAttachmentResources.</p>

--- a/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
+++ b/src/main/java/com/smartsheet/api/SheetAttachmentResources.java
@@ -143,7 +143,7 @@ public interface SheetAttachmentResources {
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
+    public Attachment attachFile(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName) throws SmartsheetException;
 
     /**
      * <p>Creates an object of AttachmentVersioningResources for access to versioning through SheetAttachmentResources.</p>

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -47,6 +47,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.io.ContentLengthInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -796,10 +797,9 @@ public abstract class AbstractResources {
         }
         HttpEntity entity = new HttpEntity();
         entity.setContentType(contentType);
-        entity.setContent(inputStream);
+        entity.setContent(new LengthEnforcerInputStream(inputStream, contentLength));
         entity.setContentLength(contentLength);
         request.setEntity(entity);
-
 
         Attachment attachment = null;
         try {

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -23,12 +23,7 @@ package com.smartsheet.api.internal;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.smartsheet.api.AuthorizationException;
-import com.smartsheet.api.InvalidRequestException;
-import com.smartsheet.api.ResourceNotFoundException;
-import com.smartsheet.api.ServiceUnavailableException;
-import com.smartsheet.api.SmartsheetException;
-import com.smartsheet.api.SmartsheetRestException;
+import com.smartsheet.api.*;
 import com.smartsheet.api.internal.http.HttpEntity;
 import com.smartsheet.api.internal.http.HttpMethod;
 import com.smartsheet.api.internal.http.HttpRequest;
@@ -36,27 +31,17 @@ import com.smartsheet.api.internal.http.HttpResponse;
 import com.smartsheet.api.internal.json.JSONSerializerException;
 import com.smartsheet.api.internal.util.StreamUtil;
 import com.smartsheet.api.internal.util.Util;
-import com.smartsheet.api.models.Attachment;
-import com.smartsheet.api.models.CopyOrMoveRowDirective;
-import com.smartsheet.api.models.CopyOrMoveRowResult;
-import com.smartsheet.api.models.PagedResult;
-import com.smartsheet.api.models.Result;
+import com.smartsheet.api.models.*;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.io.ContentLengthInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -797,7 +782,7 @@ public abstract class AbstractResources {
         }
         HttpEntity entity = new HttpEntity();
         entity.setContentType(contentType);
-        entity.setContent(new LengthEnforcerInputStream(inputStream, contentLength));
+        entity.setContent(new LengthEnforcingInputStream(inputStream, contentLength));
         entity.setContentLength(contentLength);
         request.setEntity(entity);
 

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -23,7 +23,12 @@ package com.smartsheet.api.internal;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.smartsheet.api.*;
+import com.smartsheet.api.AuthorizationException;
+import com.smartsheet.api.InvalidRequestException;
+import com.smartsheet.api.ResourceNotFoundException;
+import com.smartsheet.api.ServiceUnavailableException;
+import com.smartsheet.api.SmartsheetException;
+import com.smartsheet.api.SmartsheetRestException;
 import com.smartsheet.api.internal.http.HttpEntity;
 import com.smartsheet.api.internal.http.HttpMethod;
 import com.smartsheet.api.internal.http.HttpRequest;
@@ -31,7 +36,11 @@ import com.smartsheet.api.internal.http.HttpResponse;
 import com.smartsheet.api.internal.json.JSONSerializerException;
 import com.smartsheet.api.internal.util.StreamUtil;
 import com.smartsheet.api.internal.util.Util;
-import com.smartsheet.api.models.*;
+import com.smartsheet.api.models.Attachment;
+import com.smartsheet.api.models.CopyOrMoveRowDirective;
+import com.smartsheet.api.models.CopyOrMoveRowResult;
+import com.smartsheet.api.models.PagedResult;
+import com.smartsheet.api.models.Result;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
@@ -41,7 +50,12 @@ import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -128,7 +142,7 @@ public abstract class AbstractResources {
          * @return the exception
          * @throws SmartsheetException the smartsheet exception
          */
-        public SmartsheetRestException getException(com.smartsheet.api.models.Error error) throws SmartsheetException  {
+        public SmartsheetRestException getException(com.smartsheet.api.models.Error error) throws SmartsheetException {
 
             try {
                 return exceptionClass.getConstructor(com.smartsheet.api.models.Error.class).newInstance(error);

--- a/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
@@ -89,19 +89,18 @@ public class CommentAttachmentResourcesImpl extends AbstractResources implements
     }
 
     /**
-     * Attach file for simple upload.
+     * <p>Attach file for simple upload.</p>
      *
      * @param sheetId the sheet id
-     * @param commentId the commenr id
+     * @param commentId the comment id
+     * @param inputStream the attachment data inputStream
      * @param contentType the content type
      * @param contentLength the content length
      * @param attachmentName the name of the attachment
      * @return the attachment
-     * @throws FileNotFoundException the file not found exception
      * @throws SmartsheetException the smartsheet exception
-     * @throws UnsupportedEncodingException the unsupported encoding exception
      */
-    private Attachment attachFileWithSimpleUpload(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFileWithSimpleUpload(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/comments/" + commentId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/CommentAttachmentResourcesImpl.java
@@ -85,7 +85,7 @@ public class CommentAttachmentResourcesImpl extends AbstractResources implements
         Util.throwIfNull(sheetId, commentId, file, contentType);
         Util.throwIfEmpty(contentType);
 
-        return attachFileWithSimpleUpload(sheetId, commentId, new FileInputStream(file), contentType, file.length(), file.getName());
+        return attachFile(sheetId, commentId, new FileInputStream(file), contentType, file.length(), file.getName());
     }
 
     /**
@@ -100,7 +100,7 @@ public class CommentAttachmentResourcesImpl extends AbstractResources implements
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFile(long sheetId, long commentId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/comments/" + commentId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/main/java/com/smartsheet/api/internal/LengthEnforcerInputStream.java
+++ b/src/main/java/com/smartsheet/api/internal/LengthEnforcerInputStream.java
@@ -1,0 +1,79 @@
+package com.smartsheet.api.internal;
+
+/*
+ * #[license]
+ * Smartsheet Java SDK
+ * %%
+ * Copyright (C) 2014 - 2017 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LengthEnforcerInputStream extends FilterInputStream {
+    private long expectedLength;
+    private long totalBytesRead = 0L;
+
+    public LengthEnforcerInputStream(InputStream inputStream, long expectedLength) {
+        super(inputStream);
+        this.expectedLength = expectedLength;
+    }
+
+    @Override
+    public int read() throws IOException {
+        checkForTooManyBytes();
+        if (totalBytesRead >= expectedLength) {
+            throw new EOFException("Incorrect stream length, expected: " + expectedLength + ", actual: " + totalBytesRead);
+        }
+        int bytesRead = in.read();
+        if (bytesRead == -1) {
+            checkLength();
+        }
+        totalBytesRead += bytesRead;
+        return bytesRead;
+    }
+
+    @Override
+    public int read (byte[] b, int off, int len) throws java.io.IOException {
+        checkForTooManyBytes();
+        int bytesRead = in.read(b, off, len);
+        if (bytesRead == -1) {
+            checkLength();
+        }
+        totalBytesRead += bytesRead;
+        return bytesRead;
+    }
+
+    private void checkForTooManyBytes() throws EOFException {
+        if (totalBytesRead > expectedLength) {
+            throw new EOFException("Incorrect stream length, expected: " + expectedLength + ", actual: " + totalBytesRead);
+        }
+    }
+
+    private void checkLength() throws EOFException {
+        if (totalBytesRead != expectedLength) {
+            throw new EOFException("Incorrect stream length, expected: " + expectedLength + ", actual: " + totalBytesRead);
+        }
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        totalBytesRead = 0;
+        super.reset();
+    }
+}

--- a/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
@@ -122,10 +122,10 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
     }
 
     /**
-     * Attach file for simple upload.
+     * <p>Attach file for simple upload.</p>
      *
      * @param sheetId the sheet id
-     * @param rowId the commenr id
+     * @param rowId the row id
      * @param contentType the content type
      * @param contentLength the content length
      * @param attachmentName the name of the attachment
@@ -134,7 +134,7 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
      * @throws SmartsheetException the smartsheet exception
      * @throws UnsupportedEncodingException the unsupported encoding exception
      */
-    private Attachment attachFileWithSimpleUpload(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFileWithSimpleUpload(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/rows/" + rowId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/RowAttachmentResourcesImpl.java
@@ -118,7 +118,7 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
         Util.throwIfNull(sheetId, rowId, file, contentType);
         Util.throwIfEmpty(contentType);
 
-        return attachFileWithSimpleUpload(sheetId, rowId, new FileInputStream(file), contentType, file.length(), file.getName());
+        return attachFile(sheetId, rowId, new FileInputStream(file), contentType, file.length(), file.getName());
     }
 
     /**
@@ -134,7 +134,7 @@ public class RowAttachmentResourcesImpl extends AbstractResources implements Row
      * @throws SmartsheetException the smartsheet exception
      * @throws UnsupportedEncodingException the unsupported encoding exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFile(long sheetId, long rowId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/rows/" + rowId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
@@ -158,7 +158,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
         Util.throwIfNull(sheetId, file, contentType);
         Util.throwIfEmpty(contentType);
 
-        return attachFileWithSimpleUpload(sheetId, new FileInputStream(file), contentType, file.length(), file.getName());
+        return attachFile(sheetId, new FileInputStream(file), contentType, file.length(), file.getName());
     }
 
     /**
@@ -172,7 +172,7 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
      * @return the attachment
      * @throws SmartsheetException the smartsheet exception
      */
-    public Attachment attachFileWithSimpleUpload(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFile(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SheetAttachmentResourcesImpl.java
@@ -162,18 +162,17 @@ public class SheetAttachmentResourcesImpl extends AbstractResources implements S
     }
 
     /**
-     * Attach file for simple upload.
+     * <p>Attach file for simple upload.</p>
      *
      * @param sheetId the sheet id
+     * @param inputStream attachment data inputStream
      * @param contentType the content type
      * @param contentLength the content length
      * @param attachmentName the name of the attachment
      * @return the attachment
-     * @throws FileNotFoundException the file not found exception
      * @throws SmartsheetException the smartsheet exception
-     * @throws UnsupportedEncodingException the unsupported encoding exception
      */
-    private Attachment attachFileWithSimpleUpload(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
+    public Attachment attachFileWithSimpleUpload(long sheetId, InputStream inputStream, String contentType, long contentLength, String attachmentName)
             throws SmartsheetException {
         Util.throwIfNull(inputStream, contentType);
         return super.attachFile("sheets/" + sheetId + "/attachments", inputStream, contentType, contentLength, attachmentName);

--- a/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
@@ -10,7 +10,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -65,6 +67,21 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
         File file = new File("src/test/resources/large_sheet.pdf");
         Attachment attachment = commentAttachmentResources.attachFile(1234L, 345L, file,
                 "application/pdf");
+        assertTrue(attachment.getId() == 7265404226692996L);
+        assertEquals("Testing.PDF", attachment.getName());
+        assertEquals(AttachmentType.FILE, attachment.getAttachmentType());
+        assertEquals("application/pdf", attachment.getMimeType());
+        assertTrue(1831L == attachment.getSizeInKb());
+        assertEquals(AttachmentParentType.SHEET, attachment.getParentType());
+    }
+
+    @Test
+    public void testAttachFileSimple() throws SmartsheetException, IOException {
+        server.setResponseBody(new File("src/test/resources/attachFile.json"));
+        File file = new File("src/test/resources/large_sheet.pdf");
+        InputStream inputStream = new FileInputStream(file);
+        Attachment attachment = commentAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream,
+                "application/pdf", file.length(), file.getName());
         assertTrue(attachment.getId() == 7265404226692996L);
         assertEquals("Testing.PDF", attachment.getName());
         assertEquals(AttachmentType.FILE, attachment.getAttachmentType());

--- a/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/CommentAttachmentResourcesImplTest.java
@@ -76,11 +76,11 @@ public class CommentAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileSimple() throws SmartsheetException, IOException {
+    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
-        Attachment attachment = commentAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream,
+        Attachment attachment = commentAttachmentResources.attachFile(1234L, 345L, inputStream,
                 "application/pdf", file.length(), file.getName());
         assertTrue(attachment.getId() == 7265404226692996L);
         assertEquals("Testing.PDF", attachment.getName());

--- a/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
@@ -87,11 +87,11 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachFileWithSimpleUpload() throws SmartsheetException, IOException {
+    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
-        Attachment attachment = rowAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream, "application/pdf", file.length(), file.getName());
+        Attachment attachment = rowAttachmentResources.attachFile(1234L, 345L, inputStream, "application/pdf", file.length(), file.getName());
         assertEquals("application/pdf", attachment.getMimeType());
         assertEquals("Testing.PDF", attachment.getName());
         assertEquals(1831L, (long) attachment.getSizeInKb());
@@ -99,10 +99,10 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test(expected = SmartsheetException.class)
-    public void testAttachFileWithSimpleUploadWrongContentLength() throws SmartsheetException, IOException {
+    public void testAttachFileAsInputStreamWrongContentLength() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
-        rowAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream, "application/pdf", file.length() + 5, file.getName());
+        rowAttachmentResources.attachFile(1234L, 345L, inputStream, "application/pdf", file.length() + 5, file.getName());
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
@@ -97,4 +97,12 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
         assertEquals(1831L, (long) attachment.getSizeInKb());
         assertEquals(AttachmentType.FILE, attachment.getAttachmentType());
     }
+
+    @Test(expected = SmartsheetException.class)
+    public void testAttachFileWithSimpleUploadWrongContentLength() throws SmartsheetException, IOException {
+        server.setResponseBody(new File("src/test/resources/attachFile.json"));
+        File file = new File("src/test/resources/large_sheet.pdf");
+        InputStream inputStream = new FileInputStream(file);
+        rowAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream, "application/pdf", file.length() + 5, file.getName());
+    }
 }

--- a/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/RowAttachmentResourcesImplTest.java
@@ -12,7 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -82,5 +84,17 @@ public class RowAttachmentResourcesImplTest extends ResourcesImplBase {
         assertEquals("application/pdf", attachment.getMimeType());
         assertTrue(1831L == attachment.getSizeInKb());
         assertEquals(AttachmentParentType.SHEET, attachment.getParentType());
+    }
+
+    @Test
+    public void testAttachFileWithSimpleUpload() throws SmartsheetException, IOException {
+        server.setResponseBody(new File("src/test/resources/attachFile.json"));
+        File file = new File("src/test/resources/large_sheet.pdf");
+        InputStream inputStream = new FileInputStream(file);
+        Attachment attachment = rowAttachmentResources.attachFileWithSimpleUpload(1234L, 345L, inputStream, "application/pdf", file.length(), file.getName());
+        assertEquals("application/pdf", attachment.getMimeType());
+        assertEquals("Testing.PDF", attachment.getName());
+        assertEquals(1831L, (long) attachment.getSizeInKb());
+        assertEquals(AttachmentType.FILE, attachment.getAttachmentType());
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
@@ -12,7 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import static org.junit.Assert.*;
 
@@ -98,5 +100,20 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
         assertEquals("application/pdf", attachment.getMimeType());
         assertTrue(1831L == attachment.getSizeInKb());
         assertEquals(AttachmentParentType.SHEET, attachment.getParentType());
+    }
+
+    @Test
+    public void testAttachSimpleFile() throws SmartsheetException, IOException {
+        server.setResponseBody(new File("src/test/resources/attachFile.json"));
+        File file = new File("src/test/resources/large_sheet.pdf");
+        InputStream inputStream = new FileInputStream(file);
+        Attachment attachment = sheetAttachmentResources.attachFileWithSimpleUpload(1234L, inputStream, "application/pdf", file.length(), file.getName());
+        assertTrue(attachment.getId() == 7265404226692996L);
+        assertEquals("Testing.PDF", attachment.getName());
+        assertEquals(AttachmentType.FILE, attachment.getAttachmentType());
+        assertEquals("application/pdf", attachment.getMimeType());
+        assertTrue(1831L == attachment.getSizeInKb());
+        assertEquals(AttachmentParentType.SHEET, attachment.getParentType());
+
     }
 }

--- a/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
+++ b/src/test/java/com/smartsheet/api/internal/SheetAttachmentResourcesImplTest.java
@@ -103,11 +103,11 @@ public class SheetAttachmentResourcesImplTest extends ResourcesImplBase {
     }
 
     @Test
-    public void testAttachSimpleFile() throws SmartsheetException, IOException {
+    public void testAttachFileAsInputStream() throws SmartsheetException, IOException {
         server.setResponseBody(new File("src/test/resources/attachFile.json"));
         File file = new File("src/test/resources/large_sheet.pdf");
         InputStream inputStream = new FileInputStream(file);
-        Attachment attachment = sheetAttachmentResources.attachFileWithSimpleUpload(1234L, inputStream, "application/pdf", file.length(), file.getName());
+        Attachment attachment = sheetAttachmentResources.attachFile(1234L, inputStream, "application/pdf", file.length(), file.getName());
         assertTrue(attachment.getId() == 7265404226692996L);
         assertEquals("Testing.PDF", attachment.getName());
         assertEquals(AttachmentType.FILE, attachment.getAttachmentType());


### PR DESCRIPTION
This code already existed, but wasn't part of the public interface.
When a user supplies an InputStream for upload, they must also include the content length. Since this is easy to mess up, there is some validation included that will throw an error on the client side and close the API http connection if the content length isn't correct.