### PR TITLE
reworking of content-copying code to avoid excessive buffer sizes or copies of non-json data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 			<version>2.6.2</version>

--- a/smartsheet-sdk-java.iml
+++ b/smartsheet-sdk-java.iml
@@ -21,6 +21,7 @@
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.9" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.12" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-simple:1.7.12" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.6.2" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.2" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.6.0" level="project" />

--- a/src/main/java/com/smartsheet/api/internal/AbstractResources.java
+++ b/src/main/java/com/smartsheet/api/internal/AbstractResources.java
@@ -76,7 +76,6 @@ public abstract class AbstractResources {
 
     /** The Constant BUFFER_SIZE. */
     private final static int BUFFER_SIZE = 4098;
-    private Map<String, String> headers;
 
 
     /**
@@ -223,7 +222,7 @@ public abstract class AbstractResources {
                     try {
                         if (log.isInfoEnabled()) {
                             ByteArrayOutputStream contentCopyStream = new ByteArrayOutputStream();
-                            inputStream = StreamUtil.cloneContent(inputStream, contentCopyStream);
+                            inputStream = StreamUtil.cloneContent(inputStream, response.getEntity().getContentLength(), contentCopyStream);
                             content = StreamUtil.toUtf8StringOrHex(contentCopyStream, getResponseLogLength());
                         }
                         obj = this.smartsheet.getJsonSerializer().deserialize(objectClass, inputStream);
@@ -284,31 +283,28 @@ public abstract class AbstractResources {
         request.setEntity(entity);
 
         T obj = null;
-        String content = null;
         try {
             HttpResponse response = this.smartsheet.getHttpClient().request(request);
-            InputStream inputStream = response.getEntity().getContent();
             switch (response.getStatusCode()) {
-                case 200:
-                    // Can't be here as the stream has not ...???
+                case 200: {
+                    InputStream inputStream = response.getEntity().getContent();
+                    String content = null;
                     try {
                         if (log.isInfoEnabled()) {
                             ByteArrayOutputStream contentCopyStream = new ByteArrayOutputStream();
-                            inputStream = StreamUtil.cloneContent(inputStream, contentCopyStream);
+                            inputStream = StreamUtil.cloneContent(inputStream, response.getEntity().getContentLength(), contentCopyStream);
                             content = StreamUtil.toUtf8StringOrHex(contentCopyStream, getResponseLogLength());
                         }
                         obj = this.smartsheet.getJsonSerializer().deserializeResult(objectClass, inputStream).getResult();
-                    } catch (JsonParseException e) {
+                    } catch (JSONSerializerException e) {
                         log.info("failure parsing '{}'", content, e);
                         throw new SmartsheetException(e);
-                    } catch (JsonMappingException e) {
-                        log.info("failure mapping '{}'", content, e);
-                        throw new SmartsheetException(e);
                     } catch (IOException e) {
-                        log.info("failure loading '{}'", content, e);
+                        log.info("failure cloning content from inputStream '{}'", inputStream, e);
                         throw new SmartsheetException(e);
                     }
                     break;
+                }
                 default:
                     handleError(response);
             }
@@ -972,7 +968,8 @@ public abstract class AbstractResources {
      * @param output the output
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    public static void copyStream(InputStream input, OutputStream output) throws IOException {
+    @Deprecated // replace with StreamUtil.copyContentIntoOutputStream()
+    private static void copyStream(InputStream input, OutputStream output) throws IOException {
         byte[] buffer = new byte[BUFFER_SIZE];
         int len;
         while ((len = input.read(buffer)) != -1) {

--- a/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
@@ -253,7 +253,7 @@ public class DefaultHttpClient implements HttpClient {
                     break;
                 }
 
-                // the retry logic might consume the content stream so we set a mark and reset (if supported) just in case
+                // the retry logic might consume the content stream so we make sure it supports mark/reset and mark it
                 InputStream contentStream  = smartsheetResponse.getEntity().getContent();
                 if (!contentStream.markSupported()) {
                     // wrap the response stream in a input-stream that does support mark/reset

--- a/src/main/java/com/smartsheet/api/internal/http/HttpEntity.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpEntity.java
@@ -21,12 +21,6 @@ package com.smartsheet.api.internal.http;
  */
 
 
-
-import com.smartsheet.api.internal.util.StreamUtil;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -60,20 +54,6 @@ public class HttpEntity {
      * default ctor (needed because we're adding a copy-ctor)
      */
     public HttpEntity() {}
-
-    /**
-     * copy-ctor (because Cloneable is broken - @see http://www.artima.com/intv/bloch13.html)
-     */
-    public HttpEntity(HttpEntity original) throws IOException {
-        contentLength = original.contentLength;
-        contentType = original.contentType;
-        // we need to read and then reset (if possible) the original entity's content stream (or replace it with an exact copy)
-        // if contentLength > Integer.MAX_VALUE we have MUCH bigger problems than long->int rollover
-        ByteArrayOutputStream copyBuffer = new ByteArrayOutputStream(contentLength > 0 ? (int)contentLength : 0);
-        original.content = StreamUtil.cloneContent(original.content, copyBuffer);
-        // we now wrap our own content stream around the copy
-        content = new ByteArrayInputStream(copyBuffer.toByteArray());
-    }
 
     /**
      * Gets the content type.

--- a/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
@@ -47,8 +47,9 @@ public class HttpEntitySnapshot extends HttpEntity {
     public HttpEntitySnapshot(HttpEntity original) throws IOException {
         final String contentType = original.getContentType();
         final InputStream contentStream = original.getContent();
+        final long contentLength = original.getContentLength();
 
-        super.setContentLength(original.getContentLength());
+        super.setContentLength(contentLength);
         super.setContentType(contentType);
 
         if (contentType != null && contentType.startsWith(JSON_MIME_TYPE)) {
@@ -78,10 +79,10 @@ public class HttpEntitySnapshot extends HttpEntity {
                 original.setContent(new ByteArrayInputStream(fullContentArray));
                 // and we need a copy for potential logging purposes
                 contentArray = Arrays.copyOf(fullContentArray, Math.min(MAX_SNAPSHOT_SIZE, fullContentArray.length));
-                if (fullContentArray.length != getContentLength()) {
-                    LoggerFactory.getLogger(HttpEntitySnapshot.class).warn(
-                            "actual content-length {} doesn't match declared content-length {}",
-                            fullContentArray.length, getContentLength());
+                // we see a lot of Content-Length:-1 from certain responses - no point in logging those
+                if (contentLength != -1 && fullContentArray.length != contentLength) {
+                    LoggerFactory.getLogger(HttpEntitySnapshot.class).info("actual content-length {} doesn't match" +
+                                    " declared content-length {}", fullContentArray.length, contentLength);
                 }
             }
         } else {

--- a/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpEntitySnapshot.java
@@ -1,0 +1,119 @@
+package com.smartsheet.api.internal.http;
+
+/*
+ * #[license]
+ * Smartsheet Java SDK
+ * %%
+ * Copyright (C) 2014 - 2017 Smartsheet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * %[license]
+ */
+
+
+import com.smartsheet.api.internal.util.StreamUtil;
+import org.apache.http.entity.ContentType;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * this extension of HttpEntity is only for the purpose of creating a copy of its data stream so that the original can
+ * be used as-received and this duplicate can be logged if needed
+ */
+public class HttpEntitySnapshot extends HttpEntity {
+    private static final String JSON_MIME_TYPE = ContentType.APPLICATION_JSON.getMimeType();
+    private static final int MAX_SNAPSHOT_SIZE = StreamUtil.TEN_KB;
+
+    private byte[] contentArray;
+
+    /**
+     * this ctor creates a snapshot of the original entity (which requires its stream either support reset or it must be
+     * entirely consumed and replaced with an exact copy)
+     */
+    public HttpEntitySnapshot(HttpEntity original) throws IOException {
+        final String contentType = original.getContentType();
+        final InputStream contentStream = original.getContent();
+
+        super.setContentLength(original.getContentLength());
+        super.setContentType(contentType);
+
+        if (contentType != null && contentType.startsWith(JSON_MIME_TYPE)) {
+            // we need to read and then reset (if possible) the original entity's content stream (or replace it with an exact copy)
+            // if contentLength > Integer.MAX_VALUE we have MUCH bigger problems than long->int rollover
+            boolean sourceSupportsMark = contentStream.markSupported();
+            if (sourceSupportsMark) {
+                // here we can read up to a limited contents
+                contentArray = new byte[MAX_SNAPSHOT_SIZE];
+                contentStream.mark(MAX_SNAPSHOT_SIZE + 1);
+                int bytesRead = contentStream.read(contentArray, 0, MAX_SNAPSHOT_SIZE);
+                contentStream.reset();
+
+                // trim content array to actual size
+                if (bytesRead < MAX_SNAPSHOT_SIZE) {
+                    contentArray = Arrays.copyOf(contentArray, bytesRead);
+                }
+            } else {
+                // here we must read everything and then repackage the byte[] into an input stream to replace the original
+                byte[] fullContentArray;
+                try {
+                    fullContentArray = StreamUtil.readBytesFromStream(contentStream, StreamUtil.ONE_MB);
+                } finally {
+                    contentStream.close();
+                }
+                // having consumed the content into memory we must now replace the original stream (so it can be read by subsequent code)
+                original.setContent(new ByteArrayInputStream(fullContentArray));
+                // and we need a copy for potential logging purposes
+                contentArray = Arrays.copyOf(fullContentArray, Math.min(MAX_SNAPSHOT_SIZE, fullContentArray.length));
+                if (fullContentArray.length != getContentLength()) {
+                    LoggerFactory.getLogger(HttpEntitySnapshot.class).warn(
+                            "actual content-length {} doesn't match declared content-length {}",
+                            fullContentArray.length, getContentLength());
+                }
+            }
+        } else {
+            contentArray = String.format("**contentType '%s' not logged**", contentType).getBytes();
+        }
+    }
+
+    @Override
+    public InputStream getContent() {
+        return new ByteArrayInputStream(contentArray);
+    }
+
+    @Override
+    public void setContentLength(long contentLength) {
+        throw new UnsupportedOperationException("this class doesn't support having its content length changed");
+    }
+
+    @Override
+    public void setContentType(String contentType) {
+        throw new UnsupportedOperationException("this class doesn't support having its content type changed");
+    }
+
+    @Override
+    public void setContent(InputStream content) {
+        throw new UnsupportedOperationException("this class doesn't support having its content stream changed");
+    }
+
+    /**
+     * unfortunately there is no way to make this exposed array immutable without wrapping it or copying it, which would
+     * defeat the purpose of having a method like this for performance reasons.
+     */
+    public byte[] getContentArray() {
+        return contentArray;
+    }
+}

--- a/src/main/java/com/smartsheet/api/internal/util/StreamUtil.java
+++ b/src/main/java/com/smartsheet/api/internal/util/StreamUtil.java
@@ -33,20 +33,22 @@ import java.io.OutputStream;
  * a collection of Stream-oriented utility methods
  */
 public class StreamUtil {
+    public static final int ONE_MB = 1 << 20;
+    public static final int ONE_KB = 1 << 10;
+    public static final int TEN_KB = 10 * ONE_KB;
+
     /**
      * read all bytes from an InputStream; doesn't close input-stream
-     *
      * @param source the input stream to consume
      * @return the bytes read from 'is'
      * @throws IOException if anything goes wrong reading from 'is'
      */
     public static byte[] readBytesFromStream(InputStream source) throws IOException {
-        return readBytesFromStream(source, 1024 * 1024);
+        return readBytesFromStream(source, ONE_MB);
     }
 
     /**
      * read all bytes from an InputStream with the specified buffer size; doesn't close input-stream
-     *
      * @param source     the input stream to consume
      * @param bufferSize the buffer size to use when reading the stream
      * @return the bytes read from 'is'
@@ -54,60 +56,76 @@ public class StreamUtil {
      */
     public static byte[] readBytesFromStream(InputStream source, int bufferSize) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        copyContentIntoOutputStream(source, buffer, bufferSize);
+        copyContentIntoOutputStream(source, buffer, bufferSize, true);
         return buffer.toByteArray();
     }
 
     /**
-     * the real work-horse behind all the above methods
-     *
-     * @param source
-     * @param content
-     * @param bufferSize
+     * the real work-horse behind most of these methods
+     * @param source     the source InputStream from which to read the data (not closed when done)
+     * @param target     the target OutputStream to which to write the data (not closed when done)
+     * @param bufferSize the size of the transfer buffer to use
+     * @param readToEOF  if we should read to end-of-file of the source (true) or just 1 buffer's worth (false)
      * @throws IOException
      */
-    public static long copyContentIntoOutputStream(InputStream source, OutputStream content, int bufferSize) throws IOException {
-        byte[] tempBuf = new byte[Math.max(1024, bufferSize)];  // at least a 1k buffer
+    public static long copyContentIntoOutputStream(InputStream source, OutputStream target, int bufferSize,
+                                                   boolean readToEOF) throws IOException {
+        byte[] tempBuf = new byte[Math.max(ONE_KB, bufferSize)];  // at least a 1k buffer
         long bytesWritten = 0;
         while (true) {
             int bytesRead = source.read(tempBuf);
             if (bytesRead < 0) {
                 break;
             }
-            content.write(tempBuf, 0, bytesRead);
+            target.write(tempBuf, 0, bytesRead);
             bytesWritten += bytesRead;
+            if (!readToEOF) {
+                // prevents us from reading more than 1 buffer worth
+                break;
+            }
+
         }
         return bytesWritten;
     }
 
     /**
      * used when you want to clone a InputStream's content and still have it appear "rewound" to the stream beginning
+     * @param source       the stream around the contents we want to clone
+     * @param readbackSize the farthest we should read a resetable stream before giving up
+     * @param target       an output stream into which we place a copy of the content read from source
+     * @return the source if it was resetable; a new stream rewound around the source data otherwise
+     * @throws IOException if any issues occur with the reading of bytes from the source stream
      */
-    public static InputStream cloneContent(InputStream source, ByteArrayOutputStream target) throws IOException {
+    public static InputStream cloneContent(InputStream source, int readbackSize, ByteArrayOutputStream target) throws IOException {
         if (source == null) {
             return null;
         }
-        final boolean markSupported = source.markSupported();
-        final int maxReadBack = 1024 * 1024;
-        if (markSupported) {
-            source.mark(maxReadBack);
-        }
-        long bytesCopied = copyContentIntoOutputStream(source, target, maxReadBack);
-        if (markSupported && bytesCopied < maxReadBack) {
+        // if the source supports mark/reset then we read and then reset up to the read-back size
+        if (source.markSupported()) {
+            readbackSize = Math.max(TEN_KB, readbackSize);  // at least 10 KB (minimal waste, handles those -1 ContentLength cases)
+            source.mark(readbackSize);
+            copyContentIntoOutputStream(source, target, readbackSize, false);
             source.reset();
-            return source;  // since we could reset the source we return it
+            return source;
+        } else {
+            copyContentIntoOutputStream(source, target, ONE_MB, true);
+            byte[] fullContentBytes = target.toByteArray();
+            // if we can't reset the source we need to create a replacement stream so others can read the content
+            return new ByteArrayInputStream(fullContentBytes);
         }
-        // if we can't reset the source we need to create a replacement around what we read
-        return new ByteArrayInputStream(target.toByteArray());
+    }
+
+    /** a convenience method to reduce all the casting of HttpEntity.getContentLength() to int */
+    public static InputStream cloneContent(InputStream source, long readbackSize, ByteArrayOutputStream target) throws IOException {
+        return cloneContent(source, (int)Math.min((long)Integer.MAX_VALUE, readbackSize), target);
     }
 
     /**
      * generate a String of UTF-8 characters (or hex-digits if byteStream isn't UTF-8 chars) from byteStream,
      * truncating to maxLen (with "..." added if the result is truncated)
-     *
-     * @param byteStream
-     * @param maxLen
-     * @return
+     * @param byteStream the source of bytes to be converted to a UTF-8 String
+     * @param maxLen     the point at which to truncate the string (-1 means don't truncate) in which case "..." is appended
+     * @return the String read from the stream
      */
     public static String toUtf8StringOrHex(ByteArrayOutputStream byteStream, int maxLen) {
         if (maxLen == -1) {

--- a/src/main/java/com/smartsheet/api/retry/ShouldRetry.java
+++ b/src/main/java/com/smartsheet/api/retry/ShouldRetry.java
@@ -19,10 +19,7 @@ package com.smartsheet.api.retry;
  * %[license]
  */
 
-import com.smartsheet.api.SmartsheetException;
 import com.smartsheet.api.internal.http.HttpResponse;
-
-import java.io.IOException;
 
 /**
  * Interface for user provided retry callbacks

--- a/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
+++ b/src/test/java/com/smartsheet/api/internal/util/StreamUtilTest.java
@@ -41,7 +41,7 @@ public class StreamUtilTest {
 
         // this takes what was in inputStream, copies it into copyStream, and either resets inputStream (if supported)
         // or returns a new stream around the bytes read
-        final InputStream backupStream = StreamUtil.cloneContent(inputStream, copyStream);
+        final InputStream backupStream = StreamUtil.cloneContent(inputStream, StreamUtil.ONE_MB, copyStream);
         if (backupStream == inputStream) {
             System.out.println("same stream returned (reset)");
             // verify readBytesFromStream gets everything from the inputStream (it also verifies cloneContent resets the source)


### PR DESCRIPTION
also includes...
* moved copy-ctor HttpEntity logic into separate HttpEntitySnapshot class to make intent clearer
* other fixes for other code that potentially consumes streams without resetting them 
* various other bits of code cleanup.
* added slf4j-simple logging library for unit-tests.
