### PR TITLE
APISDK-1812

### DIFF
--- a/src/main/java/com/smartsheet/api/SheetResources.java
+++ b/src/main/java/com/smartsheet/api/SheetResources.java
@@ -574,7 +574,7 @@ public interface SheetResources {
     /**
      * <p>Sort a sheet according to the sort criteria.</p>
      *
-     * <p>It mirrors to the following Smartsheet REST API method: POST /sheet/{sheetId}/sort</p>
+     * <p>It mirrors to the following Smartsheet REST API method: POST /sheets/{sheetId}/sort</p>
      *
      * @param sheetId the sheet id
      * @param sortSpecifier the sort criteria

--- a/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
+++ b/src/main/java/com/smartsheet/api/internal/SmartsheetImpl.java
@@ -311,18 +311,6 @@ public class SmartsheetImpl implements Smartsheet {
         this.httpClient.close();
     }
 
-    /** set what request/response fields to log in trace-logging */
-    @Override
-    public void setTraces(Trace... traces) {
-        getHttpClient().setTraces(traces);
-    }
-
-    /** set whether or not to generate "pretty formatted" JSON in trace-logging */
-    @Override
-    public void setTracePrettyPrint(boolean pretty) {
-        getHttpClient().setTracePrettyPrint(pretty);
-    }
-
     /**
      * Getter of corresponding field.
      *
@@ -437,6 +425,24 @@ public class SmartsheetImpl implements Smartsheet {
     public void setMaxRetryTimeMillis(long maxRetryTimeMillis) {
         if (this.httpClient instanceof DefaultHttpClient) {
             ((DefaultHttpClient) this.httpClient).setMaxRetryTimeMillis(maxRetryTimeMillis);
+        }
+        else
+            throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());
+    }
+
+    /** set what request/response fields to log in trace-logging */
+    public void setTraces(Trace... traces) {
+        if (this.httpClient instanceof DefaultHttpClient) {
+            ((DefaultHttpClient)this.httpClient).setTraces(traces);
+        }
+        else
+            throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());
+    }
+
+    /** set whether or not to generate "pretty formatted" JSON in trace-logging */
+    public void setTracePrettyPrint(boolean pretty) {
+        if (this.httpClient instanceof DefaultHttpClient) {
+            ((DefaultHttpClient)this.httpClient).setTracePrettyPrint(pretty);
         }
         else
             throw new UnsupportedOperationException("Invalid operation for class " + this.httpClient.getClass());

--- a/src/main/java/com/smartsheet/api/internal/http/HttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/HttpClient.java
@@ -50,50 +50,7 @@ public interface HttpClient extends Closeable {
     public HttpResponse request(HttpRequest request) throws HttpClientException;
 
     /**
-     * Allocate an Apache request object based upon the request method specified in smartsheetRequest.
-     * Override this method to inject headers or set proxy information in request
-     *
-     * @param smartsheetRequest (request method and base URI come from here)
-     * @return the Apache request
-     */
-    public HttpRequestBase createApacheRequest(HttpRequest smartsheetRequest);
-
-    /**
-     * The backoff calculation routine. Uses exponential backoff. If the maximum elapsed time
-     * has expired, this calculation returns -1 causing the caller to fall out of the retry loop.
-     *
-     * @param previousAttempts
-     * @param totalElapsedTimeMillis
-     * @param error
-     * @return -1 to fall out of retry loop, positive number indicates backoff time
-     */
-    public long calcBackoff(int previousAttempts, long totalElapsedTimeMillis, Error error);
-
-    /**
-     * Called when an API request fails to determine if it can retry the request.
-     * Calls calcBackoff to determine the time to wait in between retries.
-     *
-     * @param previousAttempts number of attempts (including this one) to execute request
-     * @param totalElapsedTimeMillis total time spent in millis for all previous (and this) attempt
-     * @param response the failed HttpResponse
-     * @return true if this request can be retried
-     */
-    public boolean shouldRetry(int previousAttempts, long totalElapsedTimeMillis, HttpResponse response);
-
-    /**
      * Release connection.
      */
     public void releaseConnection();
-
-    /**
-     * set the traces for this client
-     * @param traces the fields to include in trace-logging
-     */
-    public void setTraces(Trace... traces);
-
-    /**
-     * set whether to use nicely-formatted JSON or more compact format JSON in trace logging
-     * @param pretty whether to print JSON in a "pretty" format or compact
-     */
-    public void setTracePrettyPrint(boolean pretty);
 }

--- a/src/main/java/com/smartsheet/api/models/ErrorDetail.java
+++ b/src/main/java/com/smartsheet/api/models/ErrorDetail.java
@@ -171,7 +171,7 @@ public class ErrorDetail {
     /**
      * Sets the type of the container that was partially copied
      *
-     * @param topContainerType the container ID
+     * @param topContainerType the container type
      */
     public ErrorDetail setTopContainerType(DestinationType topContainerType) {
         this.topContainerType = topContainerType;

--- a/src/main/java/com/smartsheet/api/models/SortCriterion.java
+++ b/src/main/java/com/smartsheet/api/models/SortCriterion.java
@@ -63,7 +63,7 @@ public class SortCriterion extends NamedModel<Long> {
     /**
      * Set the sort direction
      *
-     * @param direction the column ID
+     * @param direction the sort direction
      */
     public SortCriterion setDirection(SortDirection direction) {
         this.direction = direction;


### PR DESCRIPTION
log successful API calls to SLF4J
removed unnecessary methods from HttpClient to return it to its previous interface definition
make trace method calls on the Smartsheet client be conditional on HttpClient being an instance of DefaultHttpClient (otherwise raise an unsupported operation exception)