### PR TITLE
Resilience when DefaultHttpClient gets a Content-Length: and no Conte…

### DIFF
--- a/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
+++ b/src/main/java/com/smartsheet/api/internal/http/DefaultHttpClient.java
@@ -229,9 +229,13 @@ public class DefaultHttpClient implements HttpClient {
                 // Set returned entities
                 if (apacheHttpResponse.getEntity() != null) {
                     HttpEntity httpEntity = new HttpEntity();
-                    httpEntity.setContentType(apacheHttpResponse.getEntity().getContentType().getValue());
+                    if (apacheHttpResponse.getEntity().getContentType() != null) {
+                        httpEntity.setContentType(apacheHttpResponse.getEntity().getContentType().getValue());
+                    }
                     httpEntity.setContentLength(apacheHttpResponse.getEntity().getContentLength());
-                    httpEntity.setContent(apacheHttpResponse.getEntity().getContent());
+                    if (apacheHttpResponse.getEntity().getContent() != null) {
+                        httpEntity.setContent(apacheHttpResponse.getEntity().getContent());
+                    }
                     smartsheetResponse.setEntity(httpEntity);
                     responseEntityCopy = new HttpEntitySnapshot(httpEntity);
                 }


### PR DESCRIPTION
Resilience when DefaultHttpClient gets no Content-Type

The current code, if there's an entity on the response, assumes that Content-Type: is present. But sometimes it isn't; it's legitimate for an HTTP server to reply with Content-Length: 0 and omit the Content-Type:. In that case, the current code crashes with a NullPointerException. This change prevents that crash.