### PR TITLE
fix: update jackson-databind to resolve security vulnerability from 2.9.10.5 to 2.9.10.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.5</version>
+			<version>2.9.10.7</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
fix: update jackson-databind to resolve security vulnerability from 2.9.10.5 to 2.9.10.7
https://github.com/advisories/GHSA-288c-cq4h-88gq
